### PR TITLE
Add ASCII-only option, to mimic default RE2 behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: go
+go:
+  - '1.11.x'
+  - '1.12.x'
+
 env:
   global:
     - LD_LIBRARY_PATH="/usr/local/lib":${LD_LIBRARY_PATH}
     - GO111MODULE=on
+
 addons:
   apt:
     packages:
       - libonig-dev
 
-jobs:
-  include:
-    - go: 1.11.x
-      script:
-        - go test -v --cover -race
+script:
+  - go test -v --cover -race

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,13 @@ env:
   global:
     - LD_LIBRARY_PATH="/usr/local/lib":${LD_LIBRARY_PATH}
     - GO111MODULE=on
-addons:
-  apt:
-    packages:
-      - libonig-dev
+    - ONIGURUMA_VERSION='6.9.1'
 
-before_install:
-  - sudo apt-get install -y dpkg  # dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627- sudo dpkg -i libonig-dev_6.9.1-1_amd64.deb
-  - wget http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig5_6.9.1-1_amd64.deb
-  - sudo dpkg -i libonig5_6.9.1-1_amd64.deb
-  - wget http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig-dev_6.9.1-1_amd64.deb
-  - sudo dpkg -i libonig-dev_6.9.1-1_amd64.deb
+before_install: # install oniguruma manualy as trusty has only ancent 5.x
+  - sudo apt-get install -y dpkg # dpkg >= 1.17.5ubuntu5.8 fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
+  - wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"
+  - sudo dpkg -i "libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"
+  - wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig-dev_{$ONIGURUMA_VERSION}}-1_amd64.deb"
+  - sudo dpkg -i "libonig-dev_${ONIGURUMA_VERSION}-1_amd64.deb"
 script:
   - go test -v --cover -race

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: go
 go:
   - '1.11.x'
@@ -7,11 +8,16 @@ env:
   global:
     - LD_LIBRARY_PATH="/usr/local/lib":${LD_LIBRARY_PATH}
     - GO111MODULE=on
-
 addons:
   apt:
     packages:
       - libonig-dev
 
+before_install:
+  - sudo apt-get install -y dpkg  # dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627- sudo dpkg -i libonig-dev_6.9.1-1_amd64.deb
+  - wget http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig5_6.9.1-1_amd64.deb
+  - sudo dpkg -i libonig5_6.9.1-1_amd64.deb
+  - wget http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig-dev_6.9.1-1_amd64.deb
+  - sudo dpkg -i libonig-dev_6.9.1-1_amd64.deb
 script:
   - go test -v --cover -race

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install: # install oniguruma manualy as trusty has only ancent 5.x
   - sudo apt-get install -y dpkg # dpkg >= 1.17.5ubuntu5.8 fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   - wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"
   - sudo dpkg -i "libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"
-  - wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig-dev_{$ONIGURUMA_VERSION}}-1_amd64.deb"
+  - wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig-dev_${ONIGURUMA_VERSION}-1_amd64.deb"
   - sudo dpkg -i "libonig-dev_${ONIGURUMA_VERSION}-1_amd64.deb"
 script:
   - go test -v --cover -race

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - GO111MODULE=on
     - ONIGURUMA_VERSION='6.9.1'
 
-before_install: # install oniguruma manualy as trusty has only ancent 5.x
+before_install: # install oniguruma manually as trusty has only ancient 5.x
   - sudo apt-get install -y dpkg # dpkg >= 1.17.5ubuntu5.8 fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   - wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"
   - sudo dpkg -i "libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"

--- a/chelper.c
+++ b/chelper.c
@@ -17,7 +17,8 @@ int NewOnigRegex( char *pattern, int pattern_length, int option,
     *error_info = (OnigErrorInfo *) malloc(sizeof(OnigErrorInfo));
     memset(*error_info, 0, sizeof(OnigErrorInfo));
 
-    *encoding = (void*)ONIG_ENCODING_UTF8;
+    OnigEncoding use_encs[] = { *encoding };
+    onig_initialize(use_encs, sizeof(use_encs)/sizeof(use_encs[0]));
 
     *error_buffer = (char*) malloc(ONIG_MAX_ERROR_MESSAGE_LEN * sizeof(char));
 

--- a/chelper.c
+++ b/chelper.c
@@ -17,8 +17,7 @@ int NewOnigRegex( char *pattern, int pattern_length, int option,
     *error_info = (OnigErrorInfo *) malloc(sizeof(OnigErrorInfo));
     memset(*error_info, 0, sizeof(OnigErrorInfo));
 
-    OnigEncoding use_encs[] = { *encoding };
-    onig_initialize(use_encs, sizeof(use_encs)/sizeof(use_encs[0]));
+    onig_initialize_encoding(*encoding);
 
     *error_buffer = (char*) malloc(ONIG_MAX_ERROR_MESSAGE_LEN * sizeof(char));
 

--- a/regex.go
+++ b/regex.go
@@ -47,7 +47,7 @@ type Regexp struct {
 	namedGroupInfo NamedGroupInfo
 }
 
-// NewRegexp creates and initialize new Regexp with a given pattenr and option.
+// NewRegexp creates and initializes a new Regexp with the given pattern and option.
 func NewRegexp(pattern string, option int) (re *Regexp, err error) {
 	return initRegexp(&Regexp{pattern: pattern, encoding: C.ONIG_ENCODING_UTF8}, option)
 }

--- a/regex.go
+++ b/regex.go
@@ -47,15 +47,14 @@ type Regexp struct {
 	namedGroupInfo NamedGroupInfo
 }
 
+// NewRegexp creates and initialize new Regexp with a given pattenr and option.
 func NewRegexp(pattern string, option int) (re *Regexp, err error) {
-	re = &Regexp{pattern: pattern, encoding: C.ONIG_ENCODING_UTF8}
-	return initRegexp(re, option)
+	return initRegexp(&Regexp{pattern: pattern, encoding: C.ONIG_ENCODING_UTF8}, option)
 }
 
-// NewRegexpASCII is equivalent of NewRegexp but matching only ASCII.
+// NewRegexpASCII is equivalent to NewRegexp, but with the encoding restricted to ASCII.
 func NewRegexpASCII(pattern string, option int) (re *Regexp, err error) {
-	re = &Regexp{pattern: pattern, encoding: C.ONIG_ENCODING_ASCII}
-	return initRegexp(re, option)
+	return initRegexp(&Regexp{pattern: pattern, encoding: C.ONIG_ENCODING_ASCII}, option)
 }
 
 func initRegexp(re *Regexp, option int) (*Regexp, error) {
@@ -64,8 +63,8 @@ func initRegexp(re *Regexp, option int) (*Regexp, error) {
 	defer C.free(unsafe.Pointer(patternCharPtr))
 	mutex.Lock()
 	defer mutex.Unlock()
-	error_code := C.NewOnigRegex(patternCharPtr, C.int(len(re.pattern)), C.int(option), &re.regex, &re.region, &re.encoding, &re.errorInfo, &re.errorBuf)
-	if error_code != C.ONIG_NORMAL {
+	errorCode := C.NewOnigRegex(patternCharPtr, C.int(len(re.pattern)), C.int(option), &re.regex, &re.region, &re.encoding, &re.errorInfo, &re.errorBuf)
+	if errorCode != C.ONIG_NORMAL {
 		err = errors.New(C.GoString(re.errorBuf))
 	} else {
 		err = nil
@@ -105,7 +104,7 @@ func MustCompileWithOption(str string, option int) *Regexp {
 	return regexp
 }
 
-// MustCompileASCII equivalent of MustCompile but with char matching only ASCII.
+// MustCompileASCII is equivalent to MustCompile, but with the encoding restricted to ASCII.
 func MustCompileASCII(str string) *Regexp {
 	regexp, error := NewRegexpASCII(str, ONIG_OPTION_DEFAULT)
 	if error != nil {


### PR DESCRIPTION
This is a workaround, motivated by the difference in handling non-valid UTF8
bytes that Oniriguma has, compared to Go's default RE2.

See https://github.com/src-d/enry/issues/225#issuecomment-490043281

Summary of changes:
 - use modern [version of Oniguruma](https://github.com/kkos/oniguruma/releases) as it's well-maintained and is constantly improved
 - ci: test on latest 2 Go versions
 - c: `NewOnigRegex()` calls to `onig_initialize()` [1]
 - c: prevent `NewOnigRegex()` from hard-coding UTF8
 - go: expose new `MustCompileASCII()` \w default character class matching only ASCII
 - go: `MustCompile()` refactored, `initRegexp()` extracted for common UTF8/ASCII logic

Encoding was not exposed on Go API level intentionally for simplicity,
in order to avoid introducing complex struct type [2] to API surface.

 1. https://github.com/kkos/oniguruma/blob/83572e983928243d741f61ac290fc057d69fefc3/doc/API#L6
 2. https://github.com/kkos/oniguruma/blob/83572e983928243d741f61ac290fc057d69fefc3/src/oniguruma.h#L121

Signed-off-by: Alexander Bezzubov <bzz@apache.org>